### PR TITLE
feat(settings): add settings widget

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ use std::{
 };
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
+mod widgets;
+use widgets::settings_widget::SettingsWidget;
 
 // Uncomment this to work with the mostro mainnet daemon
 // const MOSTRO_PUBKEY: &str = "npub1ykvsmrmw2hk7jgxgy64zr8tfkx4nnjhq9eyfxdlg3caha3ph0skq6jr3z0";
@@ -160,7 +162,7 @@ impl App {
             0 => self.render_orders_tab(frame, body_area),
             1 => self.render_text_tab(frame, body_area, "My Trades"),
             2 => self.render_messages_tab(frame, body_area),
-            3 => self.render_text_tab(frame, body_area, "Settings"),
+            3 => self.render_settings_tab(frame, body_area),
             _ => {}
         }
 
@@ -278,6 +280,14 @@ impl App {
     fn render_text_tab(&self, frame: &mut Frame, area: Rect, text: &str) {
         let text_line = Line::from(text).centered();
         frame.render_widget(text_line, area);
+    }
+
+    fn render_settings_tab(&self, frame: &mut Frame, area: Rect) {
+        let settings_widget = SettingsWidget {
+            pubkey: self.mostro_pubkey,
+            secret: self.my_keys.secret_key().clone(),
+        };
+        frame.render_widget(settings_widget, area);
     }
 
     async fn handle_event(&mut self, event: &Event, client: Client) {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,0 +1,1 @@
+pub mod settings_widget;

--- a/src/widgets/settings_widget.rs
+++ b/src/widgets/settings_widget.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+  buffer::Buffer,
+  layout::{Constraint, Direction, Layout, Rect},
+  style::{Color, Style},
+  widgets::{Block, Widget},
+};
+use nostr_sdk::prelude::{PublicKey, SecretKey};
+use nostr_sdk::ToBech32;
+use std::str::FromStr;
+
+pub struct SettingsWidget {
+  pub pubkey: PublicKey,
+  pub secret: SecretKey,
+}
+
+impl SettingsWidget {
+  pub fn new(pubkey: PublicKey, secret: SecretKey) -> Self {
+      Self { pubkey, secret }
+  }
+}
+
+impl Widget for SettingsWidget {
+  fn render(self, area: Rect, buf: &mut Buffer) {
+      let layout = create_layout(area);
+      render_block(
+          layout[0],
+          buf,
+          "Mostro info ℹ️",
+          "Public key of this mostro operator",
+          &self.pubkey.to_bech32().unwrap(),
+      );
+      render_block(
+          layout[1],
+          buf,
+          "Secret key 🔑",
+          "Be mindful of this information",
+          &self.secret.to_bech32().unwrap(),
+      );
+  }
+}
+
+fn create_layout(area: Rect) -> Vec<Rect> {
+  Layout::default()
+      .direction(Direction::Vertical)
+      .constraints(
+          [
+              Constraint::Percentage(50),
+              Constraint::Percentage(50),
+          ]
+          .as_ref(),
+      )
+      .split(area)
+      .to_vec()
+}
+
+fn render_block(area: Rect, buf: &mut Buffer, title: &str, label: &str, value: &str) {
+  let block = Block::bordered().title(title);
+  let inner_area = block.inner(area);
+  block.render(area, buf);
+
+  render_label_and_value(inner_area, buf, label, value);
+}
+
+fn render_label_and_value(inner_area: Rect, buf: &mut Buffer, label: &str, value: &str) {
+  let label_color = Style::default().fg(Color::from_str("#14161C").unwrap());
+  let value_color = Style::default().fg(Color::White);
+
+  buf.set_string(inner_area.x + 2, inner_area.y + 1, label, label_color);
+  buf.set_string(inner_area.x + 2, inner_area.y + 3, value, value_color);
+}


### PR DESCRIPTION
# Context
Issue: https://github.com/MostroP2P/mostrui/issues/1

In Mostro web, there's a settings tab where the Mostro Nostr public key and the user's secret key are displayed. This PR introduces the first steps toward that feature in mostrui. This is how it looks in mostro web:

<img width="600" alt="Screenshot 2024-10-17 at 10 14 00 PM" src="https://github.com/user-attachments/assets/84a2e1a9-1c35-4e20-8caf-c04918330f13">


## What has been done
Added a new widget called SettingsWidget to display the Mostro Nostr public key and the user's secret key.

Here's how it looks in my terminal:
<img width="600" alt="Screenshot 2024-10-17 at 9 57 22 PM" src="https://github.com/user-attachments/assets/73bc53bd-6e3f-4ecd-9c58-a0c2d6a2678d">
(I've added light gray blocks to the screenshot, these blocks are not present in the actual terminal output)


## What to check
This is my first time working with Rust, so any feedback would be greatly appreciated, especially on:
- Whether this implementation matches your expectations.
- The general structure of placing widgets in their own folder (widgets).
