### PR TITLE
Improve UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,8 @@ impl App {
                     KeyCode::Right => {
                         if self.selected_tab < 3 {
                             self.selected_tab += 1;
+                            self.show_order = false;
+                            self.show_amount_input = false;
                         }
                     }
                     KeyCode::Enter => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,8 +201,13 @@ impl App {
         }
 
         if self.show_amount_input {
-            let popup_area = popup_area(frame.area(), 50, 20);
-            let block = Block::bordered().title("Amount input").bg(Color::Black);
+            let popup_area = popup_area(frame.area(), 55, 25);
+            let color: Color = Color::from_str("#14161C").unwrap();
+            let block = Block::bordered()
+                .title("Amount input".to_string())
+                .bg(color)
+                .title_style(Style::new().fg(Color::White))
+                .title_bottom(format!("ESC to close, ENTER to send fiat amount")); 
             let selected = self.orders.state.read().unwrap().table_state.selected();
             let state = self.orders.state.read().unwrap();
             let order = match selected {
@@ -218,7 +223,10 @@ impl App {
                 )),
             ];
 
-            let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+            let paragraph = Paragraph::new(lines)
+                .block(block)
+                .cyan()
+                .wrap(Wrap { trim: true });
             let input_paragraph = Paragraph::new(vec![Line::from(self.amount_input.value())])
                 .block(Block::default().borders(ratatui::widgets::Borders::ALL))
                 .wrap(Wrap { trim: true });
@@ -228,7 +236,7 @@ impl App {
             // Render input
             frame.render_widget(
                 input_paragraph,
-                Rect::new(popup_area.x, popup_area.y + 4, popup_area.width, 3),
+                Rect::new(popup_area.x, popup_area.y + 6, popup_area.width, 3),
             );
         }
 
@@ -249,6 +257,7 @@ impl App {
             let block = Block::bordered()
                 .title("Order details".to_string())
                 .bg(color)
+                .title_style(Style::new().fg(Color::White))
                 .title_bottom(format!("ESC to close, ENTER to {}", action));
             let sats_amount = order.sats_amount();
             let premium = match order.premium.cmp(&0) {
@@ -391,7 +400,10 @@ impl App {
                             }
                         }
                     }
-                    KeyCode::Esc => self.show_order = false,
+                    KeyCode::Esc => {
+                        self.show_order = false;
+                        self.show_amount_input = false;                   
+                    }
                     _ => {
                         if self.show_amount_input {
                             self.amount_input.handle_event(&Event::Key(*key)); // Handle keyboard events in textarea


### PR DESCRIPTION
- Currently if you were in any area and pressed Enter, you took an order. Now it only happens when you are viewing the list of orders

- If you had a popup open and you moved to a tab, it would remain open and it was quite annoying. Now the popup closes

- If you took an order with a range you were forced to write a number, if you wanted to exit you couldn't. Now pressing Esc allows you to exit

- Changed the color and background when a user is going to put the amount of fiat they want in an order with a range

- Changed the color of the popup titles to highlight them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface with improved popup dimensions and styles for input and order details.
	- Streamlined keyboard event handling for order processing based on active tabs and popups.
	- Improved error handling for out-of-range input values with clearer user feedback.

- **Bug Fixes**
	- Reset flags for input and order displays when navigating between tabs to ensure cleaner state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->